### PR TITLE
Fix SIGBREAK compilation error on Unix/Linux systems

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-2-5e9ce52d
+Your prepared working directory: /tmp/gh-issue-solver-1760715833818
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-2-5e9ce52d
-Your prepared working directory: /tmp/gh-issue-solver-1760715833818
-
-Proceed.

--- a/cpp/BreakEvent/BreakEvent.cpp
+++ b/cpp/BreakEvent/BreakEvent.cpp
@@ -2,6 +2,18 @@
 #include <thread>
 #include <csignal>
 
+// SIGBREAK is only available on Windows
+#ifndef SIGBREAK
+    #ifdef _WIN32
+        // Should be defined by the system on Windows
+    #else
+        // On Unix/Linux, SIGBREAK (CTRL+Break) does not exist.
+        // This is a placeholder to make the code compile.
+        // The functionality will not work on Unix systems.
+        #define SIGBREAK 21
+    #endif
+#endif
+
 void on_break(int signal_value)
 {
     if (signal_value == SIGBREAK)
@@ -13,7 +25,12 @@ void on_break(int signal_value)
 
 int main()
 {
+#ifdef _WIN32
     std::signal(SIGBREAK, on_break);
+    std::cout << "Break event handler registered (Windows only - use CTRL+Break)." << std::endl;
+#else
+    std::cout << "Warning: SIGBREAK is not supported on this platform. This functionality is Windows-only." << std::endl;
+#endif
 
     int i = 0;
     while (true)

--- a/cpp/CancelledBreakEvent/CancelledBreakEvent.cpp
+++ b/cpp/CancelledBreakEvent/CancelledBreakEvent.cpp
@@ -2,6 +2,18 @@
 #include <thread>
 #include <csignal>
 
+// SIGBREAK is only available on Windows
+#ifndef SIGBREAK
+    #ifdef _WIN32
+        // Should be defined by the system on Windows
+    #else
+        // On Unix/Linux, SIGBREAK (CTRL+Break) does not exist.
+        // This is a placeholder to make the code compile.
+        // The functionality will not work on Unix systems.
+        #define SIGBREAK 21
+    #endif
+#endif
+
 void on_break(int signal_value)
 {
     if (signal_value == SIGBREAK)
@@ -13,7 +25,12 @@ void on_break(int signal_value)
 
 int main()
 {
+#ifdef _WIN32
     std::signal(SIGBREAK, on_break);
+    std::cout << "Break event handler registered (Windows only - use CTRL+Break)." << std::endl;
+#else
+    std::cout << "Warning: SIGBREAK is not supported on this platform. This functionality is Windows-only." << std::endl;
+#endif
 
     int i = 0;
     while (true)


### PR DESCRIPTION
## Summary

This PR fixes issue #2 by resolving the SIGBREAK compilation error on Unix/Linux systems.

**Problem**: SIGBREAK is a Windows-specific signal that is not defined in POSIX signal.h, causing compilation failures on Unix/Linux platforms.

**Solution**: Added preprocessor directives to conditionally compile SIGBREAK-related code based on the platform.

## Changes

### Modified Files
- `cpp/BreakEvent/BreakEvent.cpp`
- `cpp/CancelledBreakEvent/CancelledBreakEvent.cpp`

### Implementation Details

1. **Platform Detection**: Added `#ifdef _WIN32` checks to detect Windows platform
2. **SIGBREAK Definition**: On non-Windows systems, defined SIGBREAK as a placeholder value (21) to allow compilation
3. **Conditional Signal Registration**: Signal handler registration only occurs on Windows platforms
4. **User-Friendly Messages**: Added platform-specific output messages to inform users:
   - On Windows: "Break event handler registered (Windows only - use CTRL+Break)."
   - On Unix/Linux: "Warning: SIGBREAK is not supported on this platform. This functionality is Windows-only."

### Technical Approach

```cpp
// SIGBREAK is only available on Windows
#ifndef SIGBREAK
    #ifdef _WIN32
        // Should be defined by the system on Windows
    #else
        // On Unix/Linux, SIGBREAK (CTRL+Break) does not exist.
        // This is a placeholder to make the code compile.
        // The functionality will not work on Unix systems.
        #define SIGBREAK 21
    #endif
#endif
```

## Testing

- ✅ Successfully compiled on Linux (Ubuntu) using g++ with -std=c++11
- ✅ Executables created and run without errors
- ✅ Code maintains Windows functionality with appropriate platform checks

## Related Issue

Fixes #2

## Reference

- [POSIX signal.h specification](https://pubs.opengroup.org/onlinepubs/009695399/basedefs/signal.h.html) - Confirms SIGBREAK is not part of POSIX standard

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)