### PR TITLE
Fix SIGINT not terminating process on Unix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-3-6f710817
+Your prepared working directory: /tmp/gh-issue-solver-1760716227046
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-3-6f710817
-Your prepared working directory: /tmp/gh-issue-solver-1760716227046
-
-Proceed.

--- a/cpp/InterruptionEvent/InterruptionEvent.cpp
+++ b/cpp/InterruptionEvent/InterruptionEvent.cpp
@@ -7,7 +7,7 @@ void on_interruption(int signal_value)
     if (signal_value == SIGINT)
     {
         std::cout << "Interrupted." << std::endl;
-        std::raise(SIGINT); // First CTRL+C does not interrupt the execution of main function on Windows 10.
+        std::exit(0); // Terminate the process to match .NET Core behavior on Unix systems
     }
 }
 


### PR DESCRIPTION
## Summary
Fixed the issue where raising SIGINT on Unix does not terminate the process. The C++ implementation now matches the behavior of the .NET Core version.

## Problem
The original implementation used `std::raise(SIGINT)` inside the signal handler, which on Unix systems caused an infinite recursive loop without terminating the process. On Unix, when SIGINT is re-raised within its own handler, it triggers the handler again instead of terminating the program.

## Solution
Replaced `std::raise(SIGINT)` with `std::exit(0)` in the SIGINT handler at `cpp/InterruptionEvent/InterruptionEvent.cpp:10`. This ensures the process terminates cleanly when receiving SIGINT, matching the default behavior of the .NET Core implementation.

## Testing
Created and ran test scripts in the `experiments/` directory that verify:
- ✅ The fixed version terminates correctly when receiving SIGINT
- ✅ The old implementation reproduced the bug (infinite "Interrupted." messages)

## Changes
- Modified `cpp/InterruptionEvent/InterruptionEvent.cpp:10` to use `std::exit(0)` instead of `std::raise(SIGINT)`

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)